### PR TITLE
ci: pin actions to SHAs and use PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,18 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.10'
-    - name: Install dependencies
+    - name: Build
       run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
+        python -m pip install --upgrade pip build
         python -m build
-        twine upload dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
## Summary
Hardens the GitHub Actions setup with two independent supply-chain improvements.

### 1. Pin actions to immutable commit SHAs
A tag like \`@v6\` is a movable pointer that the action's maintainer (or an attacker who compromises the action repo) can repoint, silently changing what CI runs. Pinning to a 40-char commit SHA makes the referenced code immutable; the human-readable version is kept in a trailing comment.

- \`actions/checkout\` -> \`df4cb1c\` (v6.0.3)
- \`actions/setup-python\` -> \`a309ff8\` (v6.2.0)
- \`pypa/gh-action-pypi-publish\` -> \`cef2210\` (v1.14.0)

### 2. PyPI Trusted Publishing (OIDC)
Replaces the long-lived \`PYPI_API_TOKEN\` + twine with tokenless OIDC publishing:
- Grants the job \`id-token: write\` and runs under the \`pypi\` environment.
- \`gh-action-pypi-publish\` exchanges a short-lived, workflow-scoped OIDC token for a one-time upload token.
- No PyPI credential is stored in the repo anymore.

## Required manual follow-up (cannot be done in code)
Do these on the respective web UIs **before the next release**, or the publish step will fail:
1. **PyPI** - register the trusted publisher (Owner \`vijaykodam\`, Repo \`kubernetes-readonly-mcp\`, Workflow \`publish.yml\`, Environment \`pypi\`).
2. **GitHub** - create an environment named \`pypi\` (Settings -> Environments).
3. After a successful OIDC publish, delete the \`PYPI_API_TOKEN\` Actions secret and revoke it on PyPI.