### PR TITLE
release: bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kubernetes-readonly-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "A read-only Kubernetes MCP server for safely interacting with Kubernetes clusters"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/kubernetes_readonly_mcp/__init__.py
+++ b/src/kubernetes_readonly_mcp/__init__.py
@@ -5,4 +5,4 @@ A Model Context Protocol server for safely interacting with Kubernetes clusters
 with read-only operations.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary
Patch version bump (0.2.0 -> 0.2.1) to cut the first release through the new PyPI Trusted Publishing (OIDC) workflow. No functional code changes.

- \`pyproject.toml\` and \`__init__.py\` kept in sync.

## After merge
Creating a GitHub release tagged \`v0.2.1\` will trigger \`publish.yml\`, which publishes to PyPI via OIDC with no stored token. This is the end-to-end verification that Trusted Publishing works.